### PR TITLE
1.9.2 doesn't like the handing in assignment on a block to something that looks like a constant

### DIFF
--- a/bin/sprinkle
+++ b/bin/sprinkle
@@ -43,15 +43,15 @@ Options are:
 BANNER
   opts.separator ""
   opts.on("-s", "--script=PATH", String,
-          "Path to a sprinkle script to run") { |OPTIONS[:path]| }
+          "Path to a sprinkle script to run") { |v| OPTIONS[:path] = v }
   opts.on("-t", "--test",
-          "Process but don't perform any actions") { |OPTIONS[:testing]| }
+          "Process but don't perform any actions") { |v| OPTIONS[:testing] = v }
   opts.on("-v", "--verbose",
-          "Verbose output") { |OPTIONS[:verbose]| }
+          "Verbose output") { |v| OPTIONS[:verbose] = v }
   opts.on("-c", "--cloud",
-          "Show powder cloud, ie. package hierarchy and installation order") { |OPTIONS[:cloud]| }
+          "Show powder cloud, ie. package hierarchy and installation order") { |v| OPTIONS[:cloud] = v }
   opts.on("-f", "--force",
-          "Force installation of all packages even if it is detected that it has been previously installed") { |OPTIONS[:force]| }
+          "Force installation of all packages even if it is detected that it has been previously installed") { |v| OPTIONS[:force] = v }
   opts.on("-h", "--help",
           "Show this help message.") { puts opts; exit }
   opts.parse!(ARGV)


### PR DESCRIPTION
It spat out:

```
sprinkle:19:in `load': sprinkle/bin/sprinkle:46: formal argument cannot be a constant (SyntaxError)
          "Path to a sprinkle script to run") { |OPTIONS[:path]| }
                                                        ^
sprinkle/bin/sprinkle:46: syntax error, unexpected '[', expecting '|'
          "Path to a sprinkle script to run") { |OPTIONS[:path]| }
                                                         ^
sprinkle/bin/sprinkle:48: formal argument cannot be a constant
...erform any actions") { |OPTIONS[:testing]| }
...                               ^
sprinkle/bin/sprinkle:48: syntax error, unexpected '[', expecting '|'
...rform any actions") { |OPTIONS[:testing]| }
...                               ^
sprinkle/bin/sprinkle:50: formal argument cannot be a constant
          "Verbose output") { |OPTIONS[:verbose]| }
                                      ^
sprinkle/bin/sprinkle:50: syntax error, unexpected '[', expecting '|'
          "Verbose output") { |OPTIONS[:verbose]| }
                                       ^
sprinkle/bin/sprinkle:52: formal argument cannot be a constant
...installation order") { |OPTIONS[:cloud]| }
...                               ^
sprinkle/bin/sprinkle:52: syntax error, unexpected '[', expecting '|'
...nstallation order") { |OPTIONS[:cloud]| }
...                               ^
sprinkle/bin/sprinkle:54: formal argument cannot be a constant
...eviously installed") { |OPTIONS[:force]| }
...                               ^
sprinkle/bin/sprinkle:54: syntax error, unexpected '[', expecting '|'
...viously installed") { |OPTIONS[:force]| }
```

I literally just changed it a simple assignment and it worked fine.

Cheers,
Carl.
