### PR TITLE
Fixed Tempfile unexpected prefix_suffix on Ruby 1.9

### DIFF
--- a/lib/sprinkle/installers/transfer.rb
+++ b/lib/sprinkle/installers/transfer.rb
@@ -107,7 +107,7 @@ module Sprinkle
           raise TemplateError.new(e, template, context)
         end
 
-        final_tempfile = Tempfile.new(prefix)
+        final_tempfile = Tempfile.new(prefix.to_s)
         final_tempfile.print(output)
         final_tempfile.close
 				final_tempfile


### PR DESCRIPTION
Ruby 1.9 doesn't like `Symbol` in `Tempfile.new`

``` ruby
>> Tempfile.new(:package_name)
ArgumentError: unexpected prefix_suffix: :package_name
```
