### PR TITLE
Fixed a problem with "custom_dir" option in source installer

### DIFF
--- a/lib/sprinkle/installers/source.rb
+++ b/lib/sprinkle/installers/source.rb
@@ -183,7 +183,7 @@ module Sprinkle
         end
 
         def build_dir #:nodoc:
-          "#{@options[:builds].first}/#{@options[:custom_dir] || base_dir}"
+          "#{@options[:builds].first}/#{@options[:custom_dir].first || base_dir}"
         end
 
         def base_dir #:nodoc:


### PR DESCRIPTION
Added a missing '@' before options[]. This caused custom_dir option to be parsed incorrectly.
