### PR TITLE
Incorrect has_group verifier

### DIFF
--- a/lib/sprinkle/verifiers/users_groups.rb
+++ b/lib/sprinkle/verifiers/users_groups.rb
@@ -26,7 +26,7 @@ module Sprinkle
       
       # Tests that the group exists
       def has_group(group)
-        @commands << "id -g #{group}"
+        @commands << "egrep -i '^#{group}:' /etc/group"
       end
     end
   end


### PR DESCRIPTION
has group did not test if a group exists, `id -g` prints group info for a user.
