### PR TITLE
serious bug in ssh actor and more debug

### DIFF
--- a/lib/sprinkle/actors/ssh.rb
+++ b/lib/sprinkle/actors/ssh.rb
@@ -107,9 +107,9 @@ module Sprinkle
               channel.on_request("exit-status") do |ch, data|
                 exit_code = data.read_long
                 if exit_code == 0
-                  logger.debug(green 'success')
+                  logger.debug(green 'success "%{cmd}"' % {:cmd => cmd})
                 else
-                  logger.debug(red('failed (%d).'%exit_code))
+                  logger.debug(red('failed (%{exit_code}) "%{cmd}"'% {:exit_code=> exit_code,:cmd => cmd}))
                 end
                 res << exit_code
                 ch.close


### PR DESCRIPTION
Hi,

I'd say the ssh actor is unusable the way it is implemented. It fires all commands async. My solution is to fire each command in a channel but go into the ssl loop immidiatly and wait for the command to finnish until the next channel is created. 

The last patch increases the debug output (it took me quite some time to figure out what happened without this output).

THX for this cool stuff
Peter
