### PR TITLE
Fix two broken specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ begin
 
     # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
   end
-  Jeweler::GemcutterTasks.new
+  #Jeweler::GemcutterTasks.new #deprecated, use Jeweler::RubyforgeTasks ?
 rescue LoadError
   puts "Jeweler (or a dependency) not available. Install it with: gem install jeweler"
 end
@@ -28,7 +28,8 @@ task "inst" => [:clobber, :build] do
   puts `gem install pkg/sprinkle-*.gem`
 end
 
-task :spec => :check_dependencies
+# Jeweler's check_dependecies no longer exists
+#task :spec => :check_dependencies
 
 desc 'Default: run specs.'
 task :default => :spec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,11 @@ require 'sprinkle'
 
 class Object
   def logger
-    @@__log_file__ ||= StringIO.new
-    @@__log__ = ActiveSupport::BufferedLogger.new @@__log_file__, ActiveSupport::BufferedLogger::Severity::INFO
+    unless defined?(@@__log__) && @@__log__
+      @@__log_file__ = StringIO.new
+      @@__log__ = ActiveSupport::BufferedLogger.new @@__log_file__
+      @@__log__.level = ActiveSupport::BufferedLogger::Severity::INFO
+    end
+    @@__log__
   end
 end

--- a/spec/sprinkle/installers/installer_spec.rb
+++ b/spec/sprinkle/installers/installer_spec.rb
@@ -62,7 +62,7 @@ describe Sprinkle::Installers::Installer do
   describe 'during installation' do
 
     it 'should request the install sequence from the concrete class' do
-      @installer.should_receive(:install_sequence).and_return(@sequence)
+      @installer.should_receive(:install_sequence).at_least(:once).and_return(@sequence)
     end
 
     describe 'when testing' do


### PR DESCRIPTION
With current versions of dependent gems, two test fail.

``` ruby
Failures:

  1) Sprinkle::Installers::Installer during installation should request the install sequence from the concrete class
     Failure/Error: @installer.should_receive(:install_sequence).and_return(@sequence)
       (#<Sprinkle::Installers::Installer:0x9b15fcc>).install_sequence(any args)
           expected: 1 time
           received: 2 times
     # ./spec/sprinkle/installers/installer_spec.rb:65:in `block (3 levels) in <top (required)>'

  2) Sprinkle should create a logger of level INFO
     Failure/Error: logger.level.should == ActiveSupport::BufferedLogger::Severity::INFO
       expected: 1
            got: 0 (using ==)
     # ./spec/sprinkle/sprinkle_spec.rb:22:in `block (2 levels) in <top (required)>'
```

In fact calling `rake` doesn't work any more due to changes in Jeweler, you need to comment out `task :spec => :check_dependencies` first.

Here is a `.rvmrc` / `Gemfile.lock` of what I'm using : https://gist.github.com/2294259
