### PR TITLE
Missing password for SSH actor

### DIFF
--- a/lib/sprinkle/actors/ssh.rb
+++ b/lib/sprinkle/actors/ssh.rb
@@ -134,7 +134,7 @@ module Sprinkle
               transfer_on_connection(source, destination, recursive, ssh)
             end
           else # direct SSH connection
-            Net::SSH.start(host, @options[:user]) do |ssh|
+            Net::SSH.start(host, @options[:user], :password => @options[:password]) do |ssh|
               transfer_on_connection(source, destination, recursive, ssh)
             end
           end


### PR DESCRIPTION
SSH actor is missing a `password` option for file transfers. This causes authentication failures and crashes the build.

This PR fixes it. 
