### PR TITLE
Fixes broken custom_dir option for source package installer

### DIFF
--- a/lib/sprinkle/installers/source.rb
+++ b/lib/sprinkle/installers/source.rb
@@ -62,6 +62,15 @@ module Sprinkle
     #     end
     #   end
     #
+    # Fifth, specifying a custom directory where the archive actually is extracted to:
+    #
+    #   package :ruby_build do
+    #     source 'https://github.com/sstephenson/ruby-build/archive/v20130227.tar.gz' do
+    #       custom_dir 'ruby-build-20130227'
+    #       custom_install './install.sh'
+    #     end
+    #   end
+    #
     # As you can see, setting options is as simple as creating a
     # block and calling the option as a method with the value as
     # its parameter.


### PR DESCRIPTION
Hi,

Here's a small patch that fixes the custom_dir option for the source installer because it's currently broken. I encountered this issue when trying to install ruby-build from source. The extraction directory name differs from the archive name, so sprinkle wouldn't cd into the actual build directory. I also added some documentation for the custom_dir option.

Cheers,
Sebastiaan
