### PR TITLE
Tweaks and modifications

### DIFF
--- a/lib/sprinkle/installers/installer.rb
+++ b/lib/sprinkle/installers/installer.rb
@@ -136,6 +136,10 @@ module Sprinkle
             commands = ["su -c '#{commands.flatten.join.gsub("'", "'\\\\''")}' -s /bin/sh #{@options[:as_user]}"]
           end
 
+          if option?(:sudo)
+            commands.map!{ |command| "sudo #{command}" }
+          end
+
           commands.flatten
         end
         


### PR DESCRIPTION
A summary of the changes:
- Added global option `:as_user` for all installers (`Sprinkle::Installers::Installer`) to run commands as specific user (`su -c '....' -s /bin/sh #{@options[:as_user]}`)
- Added `:sudo` as global option for all `Sprinkle::Installers::Installer` classes
- Updated readability of the `push_text` and `replace_text` installers
