### PR TITLE
README.{markdown,md}

### DIFF
--- a/sprinkle.gemspec
+++ b/sprinkle.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.email = "crafterm@redartisan.com"
   s.executables = ["sprinkle"]
   s.extra_rdoc_files = [
-    "README.markdown"
+    "README.md"
   ]
   
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
```
sprinkle at /Users/koenpunt/.rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/bundler/gems/sprinkle-e16a30a4d553 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["README.markdown"] are not files
```
