### PR TITLE
Use ActiveSupport::Logger instead of ActiveSupport::BufferedLogger if available

### DIFF
--- a/bin/sprinkle
+++ b/bin/sprinkle
@@ -90,8 +90,10 @@ def verbosity(options)
 end
 
 def log_level(options)
-  severity = ActiveSupport::BufferedLogger::Severity
-  Object.logger.level = options[:verbose] ? severity::DEBUG : severity::INFO
+  # ActiveSupport::BufferedLogger was deprecated and replaced by ActiveSupport::Logger in Rails 4.
+  # Use ActiveSupport::Logger if available.
+  active_support_logger = defined?(ActiveSupport::Logger) ? ActiveSupport::Logger : ActiveSupport::BufferedLogger
+  Object.logger.level = options[:verbose] ? active_support_logger::Severity::DEBUG : active_support_logger::Severity::INFO
 end
 
 require File.dirname(__FILE__) + '/../lib/sprinkle'

--- a/lib/sprinkle.rb
+++ b/lib/sprinkle.rb
@@ -37,6 +37,9 @@ class Object
   include Sprinkle::Package, Sprinkle::Policy, Sprinkle::Deployment
 
   def logger # :nodoc:
-    @@__log__ ||= ActiveSupport::BufferedLogger.new($stdout, ActiveSupport::BufferedLogger::Severity::INFO)
+    # ActiveSupport::BufferedLogger was deprecated and replaced by ActiveSupport::Logger in Rails 4.
+    # Use ActiveSupport::Logger if available.
+    active_support_logger = defined?(ActiveSupport::Logger) ? ActiveSupport::Logger : ActiveSupport::BufferedLogger
+    @@__log__ ||= active_support_logger.new($stdout, active_support_logger::Severity::INFO)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,10 @@ require 'sprinkle'
 
 class Object
   def logger
+    # ActiveSupport::BufferedLogger was deprecated and replaced by ActiveSupport::Logger in Rails 4.
+    # Use ActiveSupport::Logger if available.
+    active_support_logger = defined?(ActiveSupport::Logger) ? ActiveSupport::Logger : ActiveSupport::BufferedLogger
     @@__log_file__ ||= StringIO.new
-    @@__log__ = ActiveSupport::BufferedLogger.new @@__log_file__, ActiveSupport::BufferedLogger::Severity::INFO
+    @@__log__ = active_support_logger.new @@__log_file__, active_support_logger::Severity::INFO
   end
 end

--- a/spec/sprinkle/installers/installer_spec.rb
+++ b/spec/sprinkle/installers/installer_spec.rb
@@ -69,7 +69,10 @@ describe Sprinkle::Installers::Installer do
 
       before do
         Sprinkle::OPTIONS[:testing] = true
-        @logger = mock(ActiveSupport::BufferedLogger, :debug => true, :debug? => true)
+        # ActiveSupport::BufferedLogger was deprecated and replaced by ActiveSupport::Logger in Rails 4.
+        # Use ActiveSupport::Logger if available.
+        active_support_logger = defined?(ActiveSupport::Logger) ? ActiveSupport::Logger : ActiveSupport::BufferedLogger
+        @logger = mock(active_support_logger, :debug => true, :debug? => true)
       end
 
       it 'should not invoke the delivery mechanism with the install sequence' do

--- a/spec/sprinkle/package_spec.rb
+++ b/spec/sprinkle/package_spec.rb
@@ -352,7 +352,10 @@ CODE
       @pkg.installers = [ @installer ]
       @installer.stub!(:defaults)
       @installer.stub!(:process)
-      @logger = mock(ActiveSupport::BufferedLogger, :debug => true, :debug? => true)
+      # ActiveSupport::BufferedLogger was deprecated and replaced by ActiveSupport::Logger in Rails 4.
+      # Use ActiveSupport::Logger if available.
+      active_support_logger = defined?(ActiveSupport::Logger) ? ActiveSupport::Logger : ActiveSupport::BufferedLogger
+      @logger = mock(active_support_logger, :debug => true, :debug? => true)
       @logger.stub!(:info)
     end
 

--- a/spec/sprinkle/sprinkle_spec.rb
+++ b/spec/sprinkle/sprinkle_spec.rb
@@ -15,11 +15,17 @@ describe Sprinkle do
   it 'should automatically create a logger object on Kernel' do
     Object.should respond_to(:logger)
     logger.should_not be_nil
-    logger.class.should == ActiveSupport::BufferedLogger
+    # ActiveSupport::BufferedLogger was deprecated and replaced by ActiveSupport::Logger in Rails 4.
+    # Use ActiveSupport::Logger if available.
+    active_support_logger = defined?(ActiveSupport::Logger) ? ActiveSupport::Logger : ActiveSupport::BufferedLogger
+    logger.class.should == active_support_logger
   end
 
   it 'should create a logger of level INFO' do
-    logger.level.should == ActiveSupport::BufferedLogger::Severity::INFO
+    # ActiveSupport::BufferedLogger was deprecated and replaced by ActiveSupport::Logger in Rails 4.
+    # Use ActiveSupport::Logger if available.
+    active_support_logger = defined?(ActiveSupport::Logger) ? ActiveSupport::Logger : ActiveSupport::BufferedLogger
+    logger.level.should == active_support_logger::Severity::INFO
   end
 
 end

--- a/spec/sprinkle/verify_spec.rb
+++ b/spec/sprinkle/verify_spec.rb
@@ -180,7 +180,10 @@ describe Sprinkle::Verify do
     describe 'when testing' do
       before do
         Sprinkle::OPTIONS[:testing] = true
-        @logger = mock(ActiveSupport::BufferedLogger, :debug => true, :debug? => true)
+        # ActiveSupport::BufferedLogger was deprecated and replaced by ActiveSupport::Logger in Rails 4.
+        # Use ActiveSupport::Logger if available.
+        active_support_logger = defined?(ActiveSupport::Logger) ? ActiveSupport::Logger : ActiveSupport::BufferedLogger
+        @logger = mock(active_support_logger, :debug => true, :debug? => true)
       end
 
       it 'should not call process on the delivery' do


### PR DESCRIPTION
ActiveSupport::BufferedLogger was deprecated and replaced by ActiveSupport::Logger in Rails 4. Use ActiveSupport::Logger if available.

This could be moved into a central location somewhere... but where?
