### PR TITLE
Fix matches_local file verifier when used with sudo

### DIFF
--- a/lib/sprinkle/verifiers/file.rb
+++ b/lib/sprinkle/verifiers/file.rb
@@ -36,7 +36,7 @@ module Sprinkle
         raise "Couldn't find local file #{localfile}" unless ::File.exists?(localfile)
         require 'digest/md5'
         local = Digest::MD5.hexdigest(::File.read(localfile))
-        @commands << %{[ "X$(md5sum #{remotefile}|cut -d\\  -f 1)" = "X#{local}" ]}
+        @commands << %{bash -c '[ "X$(md5sum #{remotefile}|cut -d\\  -f 1)" = "X#{local}" ]'}
       end
     end
   end

--- a/spec/sprinkle/verify_spec.rb
+++ b/spec/sprinkle/verify_spec.rb
@@ -80,7 +80,7 @@ describe Sprinkle::Verify do
     end
 
     it 'should do a md5sum to see if a file matches local file' do
-      @verification.commands.should include(%{[ "X$(md5sum my_file.txt|cut -d\\  -f 1)" = "Xed20d984b757ad5291963389fc209864" ]})
+      @verification.commands.should include(%{bash -c '[ "X$(md5sum my_file.txt|cut -d\\  -f 1)" = "Xed20d984b757ad5291963389fc209864" ]'})
     end
 
     it 'should do a "test -d" on the has_directory check' do


### PR DESCRIPTION
Before:

```
$ sudo touch /root/my_file.txt
$ sudo [ "X$(md5sum /root/my_file.txt|cut -d\  -f 1)" = "Xd41d8cd98f00b204e9800998ecf8427e" ]
md5sum: /root/my_file.txt: Permission denied
```

After:

```
$ sudo touch /root/my_file.txt
$ sudo bash -c '[ "X$(md5sum /root/my_file.txt|cut -d\  -f 1)" = "Xd41d8cd98f00b204e9800998ecf8427e" ]'
$ echo $?
0
```
