### PR TITLE
Use error exit code on failure

### DIFF
--- a/lib/sprinkle/deployment.rb
+++ b/lib/sprinkle/deployment.rb
@@ -83,7 +83,7 @@ module Sprinkle
         exit 1
       rescue Sprinkle::Errors::TransferFailure => e
         e.print_summary
-        exit 1
+        exit 2
       ensure
         # do any cleanup our actor may need to close network sockets, etc
         @style.teardown if @style.respond_to?(:teardown)        


### PR DESCRIPTION
Just error code 1 for now.  Good enough for most cases.

May want to revisit later and set the code based on type of error or returned exit code from remote command.
