### PR TITLE
Default Capistrano to not use sudo

### DIFF
--- a/lib/sprinkle/actors/capistrano.rb
+++ b/lib/sprinkle/actors/capistrano.rb
@@ -87,7 +87,7 @@ module Sprinkle
         inst=@installer
         @log_recorder = log_recorder = Sprinkle::Utility::LogRecorder.new
         define_task(name, roles) do
-          via = fetch(:run_method, :run)
+          via = fetch(:run_method, fetch(:use_sudo, true) ? :sudo : :run)
           commands.each do |command|
             if command == :TRANSFER
               opts.reverse_merge!(:recursive => true)


### PR DESCRIPTION
See
#61

If the user wants to default commands to using sudo, they can add below to their `deploy.rb`

``` ruby
set :run_method, :sudo
```
