### PR TITLE
Show capistrano output as it was in 0.4.x

### DIFF
--- a/lib/sprinkle/actors/capistrano.rb
+++ b/lib/sprinkle/actors/capistrano.rb
@@ -108,9 +108,9 @@ module Sprinkle
             else
               # this reset the log
               log_recorder.reset command
-              invoke_command(command, {:via => via}) do |c,s,d| 
-                # record the stream and data
-                log_recorder.log(s, d)
+              invoke_command(command, {:via => via}) do |ch, stream, out|
+                ::Capistrano::Configuration.default_io_proc.call(ch, stream, out)
+                log_recorder.log(stream, out)
               end
             end
           end


### PR DESCRIPTION
The silent output was introduced in
https://github.com/sprinkle-tool/sprinkle/commit/a6e7356318c41a6a67307932182ec8e51bce8b70#L0L91
