### PR TITLE
Post install hooks happen in wrong order when using sudo with transfer installer

### DIFF
--- a/lib/sprinkle/installers/installer.rb
+++ b/lib/sprinkle/installers/installer.rb
@@ -95,15 +95,25 @@ module Sprinkle
       end
 
       def pre(stage, *commands, &block)
+        options = commands.extract_options!
+        commands.concat(commands_from_block(block))
         @pre[stage] ||= []
-        @pre[stage] += commands
-        @pre[stage] += commands_from_block(block)
+        if options.fetch(:prepend, false)
+          @pre[stage].unshift(commands)
+        else
+          @pre[stage] << commands
+        end
       end
 
       def post(stage, *commands, &block)
+        options = commands.extract_options!
+        commands.concat(commands_from_block(block))
         @post[stage] ||= []
-        @post[stage] += commands
-        @post[stage] += commands_from_block(block) 
+        if options.fetch(:prepend, false)
+          @post[stage].unshift(commands)
+        else
+          @post[stage] << commands
+        end
       end
       
       def commands_from_block(block)

--- a/lib/sprinkle/installers/transfer.rb
+++ b/lib/sprinkle/installers/transfer.rb
@@ -103,7 +103,7 @@ module Sprinkle
         if sudo?
           final = @destination
           @destination = "/tmp/sprinkle_#{File.basename(@destination)}"
-          post :install, "#{sudo_cmd}mv #{@destination} #{final}"
+          post :install, "#{sudo_cmd}mv #{@destination} #{final}", :prepend => true
         end
         owner(options[:owner]) if options[:owner]
         mode(options[:mode]) if options[:mode]

--- a/spec/sprinkle/installers/transfer_spec.rb
+++ b/spec/sprinkle/installers/transfer_spec.rb
@@ -73,6 +73,26 @@ describe Sprinkle::Installers::Transfer do
 
     end
 
+    context 'should prepend pre/post commands' do
+      before do
+        @installer = create_transfer @source, @destination do
+          pre :install, 'initial-op1'
+          post :install, 'initial-op2'
+        end
+
+        @installer.pre :install, 'op1', :prepend => true
+        @installer.post :install, 'op2', :prepend => true
+
+        @installer_commands = @installer.install_sequence
+
+        @delivery = @installer.delivery
+      end
+
+      it "should call the pre and post install commands around the file transfer and should have prepended the later added callbacks" do
+        @installer_commands.should == ['op1', 'initial-op1', :TRANSFER, 'op2', 'initial-op2']
+      end
+    end
+
     context 'multiple pre/post commands' do
       before do
         @installer = create_transfer @source, @destination do


### PR DESCRIPTION
Had an issue with `post :install` commands on a `sudo` transfer because the move after the transfer from the tmp to final destination happened after my own `post :install` commands. Now added an `:prepend` option for `post` and `pre`, so the the move can be prepended before any user commands.
