### PR TITLE
No need to create a new instance of self

### DIFF
--- a/lib/sprinkle/package.rb
+++ b/lib/sprinkle/package.rb
@@ -139,11 +139,9 @@ module Sprinkle
       end
       
       def instance(*args)
-        p=Package.new(name, @metadata) {}
+        p = self.clone
         p.opts = args.extract_options!
         p.args = args
-        p.instance_variable_set("@block", @block)
-        p.instance_eval &@block
         p
       end
       


### PR DESCRIPTION
I discovered there is no need to construct a new instance of `Package`, and that cloning `self` is actually enough (according to the tests, correct me if i'm wrong)

Also there is no need to call `instance_eval` twice
