### PR TITLE
Updated package rendering so that opts are available in template

### DIFF
--- a/.tm_properties
+++ b/.tm_properties
@@ -1,0 +1,1 @@
+projectDirectory = "$CWD"

--- a/lib/sprinkle/package/rendering.rb
+++ b/lib/sprinkle/package/rendering.rb
@@ -4,31 +4,32 @@ require 'digest/md5'
 module Sprinkle::Package
   module Rendering
     extend ActiveSupport::Concern
-    
+
     included do
       self.send :include, Helpers
     end
-    
-    def template(src, bound=binding)
+
+    def template(src, context={})
+      context.reverse_merge!(opts)
       eruby = Erubis::Eruby.new(src)
-      output = eruby.result(bound)
+      output = eruby.evaluate(context)
     rescue Object => e
-      raise Sprinkle::Errors::TemplateError.new(e, src, bound)
+      raise Sprinkle::Errors::TemplateError.new(e, src, context)
     end
-    
-    def render(file)
+
+    def render(file, context={})
       contents=File.read(expand_filename(file))
-      template(contents)
+      template(contents, context)
     end
-    
+
     module Helpers
       def md5(s)
         Digest::MD5.hexdigest(s)
       end
     end
-    
-    private 
-    
+
+    private
+
     def expand_filename(n)
       return n.to_s if n.to_s.starts_with? "/"
       ["./templates/#{n}","./templates/#{n}.erb"].each do |f|
@@ -36,6 +37,6 @@ module Sprinkle::Package
       end
       raise "template file not found"
     end
-    
+
   end
 end

--- a/spec/sprinkle/extensions/rendering_spec.rb
+++ b/spec/sprinkle/extensions/rendering_spec.rb
@@ -1,8 +1,9 @@
 require File.expand_path("../../spec_helper", File.dirname(__FILE__))
 
 describe Sprinkle::Package::Rendering, 'rendering' do
-  
+
   before do
+    @root = File.expand_path(File.join(File.dirname(__FILE__), "../.."))
     @package = package :something do
     end
   end
@@ -10,24 +11,45 @@ describe Sprinkle::Package::Rendering, 'rendering' do
   it "should be able to calculate md5s" do
     @package.md5("test").should == "098f6bcd4621d373cade4e832627b4f6"
   end
-  
+
   it "should allow passing locals to template" do
-    t=@package.template("hello <%= world %>", :world => "world")
+    t = @package.template("hello <%= @world %>", :world => "world")
     t.should == "hello world"
   end
-  
-  it "should be able to render a file from absolute path" do
-    path=File.join(__FILE__, "../../templates/test.erb")
-    t=@package.render("test")
-    t.should == "hello " 
-  end
-  
+
   it "should be able to render a file from templates" do
-    @package = package :new do
-      @world = "world"
+    Dir.chdir(@root) do
+      t = @package.render("test")
+      t.should == "hello "
     end
-    t=@package.render("test")
-    t.should == "hello world" 
   end
-    
+
+  it "should be able to render a file from absolute path" do
+    path = File.join(@root, "templates/test.erb")
+    t = @package.render(path)
+    t.should == "hello "
+  end
+  
+  it "should accept options as second argument" do
+    path = File.join(@root, "templates/test.erb")
+    t = @package.render(path, :world => "world")
+    t.should == "hello world"
+  end
+
+  it "should have the package opts available in the template" do
+    p = @package.instance :world => "earth"
+    Dir.chdir(@root) do
+      t = p.render("test")
+      t.should == "hello earth"
+    end
+  end
+
+  it "should override package opts with render opts" do
+    p = @package.instance :world => "earth"
+    Dir.chdir(@root) do
+      t = p.render("test", :world => "world")
+      t.should == "hello world"
+    end
+  end
+
 end

--- a/spec/templates/opts_test.erb
+++ b/spec/templates/opts_test.erb
@@ -1,0 +1,1 @@
+hello <%= @world %>

--- a/spec/templates/test.erb
+++ b/spec/templates/test.erb
@@ -1,0 +1,1 @@
+hello <%= @world %>


### PR DESCRIPTION
Some modifications to rendering of files, also for better support of the `defaults` option of my other PR when one wants to use these defaults in a template.

The ERB rendering doesn't use the local binding anymore, but now merges `opts` and given options (second argument of both `render` and `template`) and use that as context.

Example:
This

``` ruby
package :nginx do
  file '/etc/nginx/nginx.conf', :contents => render('nginx', :worker_processes => opts[:worker_processes] || 2)
end
```

with the template:

``` erb
user www-data;
worker_processes <%= @worker_processes %>;
pid /run/nginx.pid;

events {
    worker_connections 768;
    # multi_accept on;
}
...
```

NB. This causes that local variables won't be passed on to the template anymore.
