### PR TITLE
Added :env option for runner to easily set environment variables for the command

### DIFF
--- a/lib/sprinkle/installers/runner.rb
+++ b/lib/sprinkle/installers/runner.rb
@@ -15,33 +15,50 @@ module Sprinkle
     #     runner [ "make world", "destroy world" ]
     #   end
     #
+    # Environment variables can be supplied throught the :env option.
+    #
+    #   package :magic_beans do
+    #     runner "make world", :env => {
+    #       :PATH => '/this/is/my/path:$PATH'
+    #     }
+    #   end
+    #
     class Runner < Installer
-      
+
       api do
         def runner(*cmds, &block)
           options = cmds.extract_options!
           install Runner.new(self, cmds, options, &block)
         end
-        
+
         # runs 'echo noop' on the remote host
         def noop
           install Runner.new(self, "echo noop")
         end
       end
-      
+
       attr_accessor :cmds #:nodoc:
       def initialize(parent, cmds, options = {}, &block) #:nodoc:
         super parent, options, &block
+        @env = options.delete(:env)
         @cmds = [*cmds].flatten
         raise "you need to specify a command" if cmds.nil?
       end
-      
+
       protected
-        
+
+        def env_str #:nodoc:
+          @env_str ||= @env.inject("env ") do |s, (k,v)|
+            s << "#{k.to_s.upcase}=#{v} "
+          end
+        end
+
         def install_commands #:nodoc:
-          sudo? ? 
-            @cmds.map { |cmd| "#{sudo_cmd}#{cmd}"} :
-            @cmds
+          cmds = @env ? @cmds.map { |cmd| "#{env_str}#{cmd}"} : @cmds
+
+          sudo? ?
+            cmds.map { |cmd| "#{sudo_cmd}#{cmd}"} :
+            cmds
         end
     end
   end

--- a/spec/sprinkle/installers/runner_spec.rb
+++ b/spec/sprinkle/installers/runner_spec.rb
@@ -2,46 +2,63 @@ require File.expand_path("../../spec_helper", File.dirname(__FILE__))
 
 describe Sprinkle::Installers::Runner do
 
-	before do
-		@package = mock(Sprinkle::Package, :name => 'package', :sudo? => false)
-	end
+  before do
+    @package = mock(Sprinkle::Package, :name => 'package', :sudo? => false)
+  end
 
-	def create_runner(*cmds)
-	  options=cmds.extract_options!
-		Sprinkle::Installers::Runner.new(@package, cmds, options)
-	end
+  def create_runner(*cmds)
+    options=cmds.extract_options!
+    Sprinkle::Installers::Runner.new(@package, cmds, options)
+  end
 
-	describe 'when created' do
-		it 'should accept a single cmd to run' do
-			@installer = create_runner 'teste'
-			@installer.cmds.should == ['teste']
-		end
-		
-		it 'should accept an array of commands to run' do
-			@installer = create_runner ['teste', 'world']
-			@installer.cmds.should == ['teste', 'world']
-			@installer.install_sequence.should == ['teste', 'world']
-	  end
-	end
-
-	describe 'during installation' do
-		
-		it 'should use sudo if specified locally' do
-		  @installer = create_runner 'teste', :sudo => true
-		  @install_commands = @installer.send :install_commands
-		  @install_commands.should == ['sudo teste']
-	  end
-	  
-	  it "should accept multiple commands" do
-	    @installer = create_runner 'teste', 'test2'
-	    @install_commands = @installer.send :install_commands
-	    @install_commands.should == ['teste','test2']
+  describe 'when created' do
+    it 'should accept a single cmd to run' do
+      @installer = create_runner 'teste'
+      @installer.cmds.should == ['teste']
     end
 
-		it 'should run the given command for all specified packages' do
-		  @installer = create_runner 'teste'
-			@install_commands = @installer.send :install_commands
-			@install_commands.should == ['teste']
-		end
-	end
+    it 'should accept an array of commands to run' do
+      @installer = create_runner ['teste', 'world']
+      @installer.cmds.should == ['teste', 'world']
+      @installer.install_sequence.should == ['teste', 'world']
+    end
+  end
+
+  describe 'during installation' do
+
+    it 'should use sudo if specified locally' do
+      @installer = create_runner 'teste', :sudo => true
+      @install_commands = @installer.send :install_commands
+      @install_commands.should == ['sudo teste']
+    end
+
+    it "should accept env options and convert to uppercase" do
+      @installer = create_runner 'command1', :env => {
+        :z => 'foo',
+        :PATH => '/some/path',
+        :user => 'deploy',
+        :a => 'bar'
+      }
+      @install_commands = @installer.send :install_commands
+      command_parts = @install_commands.first.split(/ /)
+
+      command_parts.shift.should == 'env'
+      command_parts.pop.should == 'command1'
+
+      command_parts.should =~ ['PATH=/some/path', 'USER=deploy', 'Z=foo', 'A=bar']
+
+    end
+
+    it "should accept multiple commands" do
+      @installer = create_runner 'teste', 'test2'
+      @install_commands = @installer.send :install_commands
+      @install_commands.should == ['teste','test2']
+    end
+
+    it 'should run the given command for all specified packages' do
+      @installer = create_runner 'teste'
+      @install_commands = @installer.send :install_commands
+      @install_commands.should == ['teste']
+    end
+  end
 end


### PR DESCRIPTION
 Environment variables can be supplied throught the `:env` option.

``` ruby
package :magic_beans do
  runner "make world", :env => {
    :PATH => '/this/is/my/path:$PATH'
  }
end
```

Will result in:

``` bash
env PATH=/this/is/my/path:$PATH make world
```
