### PR TITLE
Fix a problem where Tempfiles are removed by Ruby GC before they are used

### DIFF
--- a/lib/sprinkle/installers/file.rb
+++ b/lib/sprinkle/installers/file.rb
@@ -87,10 +87,10 @@ module Sprinkle
       end
 
       def setup_source
-        file=Tempfile.new(@package.name.to_s)
-        file.print(@contents)
-        file.close
-        @sourcepath = file.path
+        @file=Tempfile.new(@package.name.to_s)
+        @file.print(@contents)
+        @file.close
+        @sourcepath = @file.path
       end
 
     end


### PR DESCRIPTION
When Tempfile objects are cleaned by the Ruby garbage collector, it will delete the file as well as the object. Since "file" was a local variable in the File installer, it was possible that the file was deleted by GC before the installer was actually run.

By changing the local variable to be an instance variable we avoid this problem.
