### PR TITLE
Fix GitHub URL in sprinkle executable

### DIFF
--- a/bin/sprinkle
+++ b/bin/sprinkle
@@ -28,7 +28,7 @@ parser = OptionParser.new do |opts|
 Sprinkle
 ========
 
-http://github.com/crafterm/sprinkle
+http://github.com/sprinkle-tool/sprinkle
 
 Sprinkle is a software provisioning tool you can use to build remote servers with. eg. to
 install a Rails or Merb stack on a brand new slice directly after its been created. It uses


### PR DESCRIPTION
The sprinkle executable links to the old location for sprinkle. Link to the current URL instead.
