### PR TITLE
Add generic command installer

### DIFF
--- a/lib/sprinkle/installers/command.rb
+++ b/lib/sprinkle/installers/command.rb
@@ -1,0 +1,37 @@
+module Sprinkle
+  module Installers
+    # Beware, strange "installer" coming your way.
+    #
+    # This command installer runs arbitary commands
+    #
+    # == Example Usage
+    #
+    # If you user has access to 'sudo' and theres a file that requires
+    # priveledges, you can pass :sudo => true 
+    #
+    class Command < Installer
+      attr_reader :command #:nodoc:
+
+      api do
+        def command(command, options = {}, &block)
+          install Command.new(self, command, options, &block)
+        end
+      end
+
+      def initialize(parent, command, options={}, &block) #:nodoc:
+        super parent, options, &block
+        @command = command
+      end
+
+      def announce #:nodoc:
+        log "--> Running '#{@command}'"
+      end
+
+      protected
+
+        def install_commands #:nodoc:
+          "#{sudo_cmd}#{@command}"
+        end
+    end
+  end
+end

--- a/spec/sprinkle/installers/command_spec.rb
+++ b/spec/sprinkle/installers/command_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+describe Sprinkle::Installers::Command do
+
+  before do
+    @package = double(Sprinkle::Package, :name => 'package', :sudo? => false)
+    @options = {:sudo => true}
+  end
+
+  def command(command, options={}, &block)
+    Sprinkle::Installers::Command.new(@package, command, options, &block)
+  end
+
+  describe 'when created' do
+    it 'should accept a single package to install' do
+      @installer = command 'echo "moo"'
+      @installer.command.should == 'echo "moo"'
+    end
+  end
+
+  describe 'during installation' do
+
+    before do
+      @installer = command 'echo "moo"' do
+        pre :install, 'op1'
+        post :install, 'op2'
+      end
+      @install_commands = @installer.send :install_commands
+    end
+
+    it 'should invoke the command installer for all specified packages' do
+      @install_commands.should == %q[echo "moo"]
+    end
+
+    it 'should automatically insert pre/post commands for the specified package' do
+      @installer.send(:install_sequence).should == [ 'op1', "echo \"moo\"", 'op2' ]
+    end
+
+    describe 'with sudo' do
+      before do
+        @installer = command 'echo "moo"', :sudo => true
+        @install_commands = @installer.send :install_commands
+      end
+      it 'should invoke sudo if sudo option passed' do
+        @install_commands.should == %q[sudo echo "moo"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows you to run an arbitary command/script as an installer, for when you want
to do something slightly non-standard (in my case adding a ppa and update apt
but only if not already setup so I want to use verify and hooks etc).
