### PR TITLE
When using sudo, make sure each command is prefixed

### DIFF
--- a/lib/sprinkle/actors/ssh.rb
+++ b/lib/sprinkle/actors/ssh.rb
@@ -119,7 +119,7 @@ module Sprinkle
       
       def verify(verifier, roles) #:nodoc:
         # issue all the verification steps in a single SSH command
-        commands=[verifier.commands.join(" && ")]
+        commands=[prepare_commands(verifier.commands).join(" && ")]
         process(verifier.package.name, commands, roles)
       rescue SSHCommandFailure
         false


### PR DESCRIPTION
If `sudo` is used, packing all commands into one line, using `&&` won't work except for the first command. This fixes the problem.
