### PR TITLE
Added pecl installer for building php extensions

### DIFF
--- a/lib/sprinkle/installers/pecl.rb
+++ b/lib/sprinkle/installers/pecl.rb
@@ -1,0 +1,81 @@
+module Sprinkle
+  module Installers
+    # = Pecl extension installed
+    #
+    # Installs the specified pecl extension
+    #
+    # == Example Usage
+    #
+    #   package :php_stuff do
+    #     pecl 'mongo'
+    #     verify { has_pecl 'mongo' }
+    #   end
+    #
+    # You can optionally pass a version number to both `pecl` and `has_pecl`:
+    #
+    #   package :php_stuff do
+    #     pecl 'mongo', :version => "1.4.3"
+    #     verify { has_pecl 'mongo', :version => "1.4.3" }
+    #   end
+    #
+    # Some extensions need an ini file. You can have that generated, by passing the `:ini_file` option:
+    #
+    #   package :php_stuff do
+    #     pecl 'mongo', :ini_file => true
+    #   end
+    #
+    # If you need more fine grained control of the location or contents of the ini file, use:
+    #
+    #   package :php_stuff do
+    #     pecl 'mongo', :ini_file => { :path => "/etc/php5/apache2/php.ini",
+    #                                  :content => "extension=mongo.so",
+    #                                  :sudo => true }
+    #   end
+    #
+    class Pecl < Installer
+      attr_accessor :package_name, :package_version
+
+      api do
+        def pecl(package_name, options = {}, &block)
+          install Pecl.new(self, package_name, options, &block)
+        end
+      end
+
+      verify_api do
+        def has_pecl(package_name, options = {})
+          @commands = "TERM= pecl list | grep '^#{package_name}\\\\s*" + (options[:version] ? options[:version].to_s : "") + "'"
+        end
+      end
+
+      def initialize(parent, package_name, options = {}, &block) #:nodoc:
+        super parent, &block
+        @package_name = package_name
+        @package_version = options[:version]
+        @ini_file = options[:ini_file]
+        if @ini_file
+          if @ini_file.is_a?(String)
+            text = @ini_file
+          elsif @ini_file.is_a?(Hash) && @ini_file[:content]
+            text = @ini_file[:content]
+          else
+            text = "extension=#{@package_name}.so"
+          end
+          if @ini_file.is_a?(Hash) && @ini_file[:path]
+            path = @ini_file[:path]
+          else
+            path = "/etc/php5/conf.d/#{@package_name}.ini"
+          end
+          use_sudo = @ini_file.is_a?(Hash) && !@ini_file[:sudo].nil? ? @ini_file[:sudo] : true
+          post(:install) << file(path, :content => text, :sudo => use_sudo)
+        end
+      end
+
+      protected
+        def install_commands #:nodoc:
+          cmd = "TERM= pecl install --alldeps #{@package_name}"
+          cmd << "-#{@package_version}" if @package_version
+          cmd
+        end
+    end
+  end
+end

--- a/spec/sprinkle/installers/pecl_spec.rb
+++ b/spec/sprinkle/installers/pecl_spec.rb
@@ -1,0 +1,77 @@
+require File.expand_path("../../spec_helper", File.dirname(__FILE__))
+
+describe Sprinkle::Installers::Pecl do
+  before do
+    @package = double(Sprinkle::Package, :name => 'spec', :class => double(Sprinkle::Package, :installer_methods => []))
+  end
+
+  describe 'providing just package name' do
+    before do
+      @installer = Sprinkle::Installers::Pecl.new(@package, 'spec')
+    end
+
+    describe 'during installation' do
+      it 'should invoke the pecl installer' do
+        @install_commands = @installer.send :install_commands
+        @install_commands.should == "TERM= pecl install --alldeps spec"
+      end
+    end
+  end
+
+  describe 'providing explicit version' do
+    before do
+      @installer = Sprinkle::Installers::Pecl.new(@package, 'spec', :version => '1.1.1')
+    end
+
+    describe 'during installation' do
+      it 'should invoke the pecl installer' do
+        @install_commands = @installer.send :install_commands
+        @install_commands.should == "TERM= pecl install --alldeps spec-1.1.1"
+      end
+    end
+  end
+
+  describe 'providing ini_file option' do
+    describe 'during installation' do
+      it 'should transfer file with default arguments in post install' do
+        @installer = Sprinkle::Installers::Pecl.new(@package, 'spec', :ini_file => true) do
+          self.stub(:file) do |path,options|
+            path.should == "/etc/php5/conf.d/spec.ini"
+            options[:content].should == "extension=spec.so"
+            options[:sudo].should == true
+            "post install file transfer"
+          end
+        end
+        @install_sequence = @installer.install_sequence
+        @install_sequence.should include("TERM= pecl install --alldeps spec")
+        @install_sequence.should include("post install file transfer")
+      end
+
+      it 'should use custom path and content if provided' do
+        @installer = Sprinkle::Installers::Pecl.new(@package, 'spec', :ini_file => {:path => "/custom/path", :content => "hello"}) do
+          self.stub(:file) do |path,options|
+            path.should == "/custom/path"
+            options[:content].should == "hello"
+          end
+        end
+      end
+
+      it 'should use custom content if string passed' do
+        @installer = Sprinkle::Installers::Pecl.new(@package, 'spec', :ini_file => "hello") do
+          self.stub(:file) do |path,options|
+            options[:content].should == "hello"
+          end
+        end
+      end
+
+      it 'should NOT use sudo if explicitly denied' do
+        @installer = Sprinkle::Installers::Pecl.new(@package, 'spec', :ini_file => {:sudo => false}) do
+          self.stub(:file) do |path,options|
+            options[:sudo].should == false
+          end
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Closely modelled after the pear installer. For installing php binary extensions, such as database drivers etc.
