### PR TITLE
Fix sudo commands for ssh

### DIFF
--- a/lib/sprinkle/actors/ssh.rb
+++ b/lib/sprinkle/actors/ssh.rb
@@ -160,11 +160,12 @@ module Sprinkle
         end
         
         def execute_on_host(commands,host) #:nodoc:
+          
           prepare_commands(commands).each do |cmd|
             case cmd
-              when cmd.is_a?(Commands::Reconnect) then
+              when Commands::Reconnect then
                 reconnect host
-              when cmd.is_a?(Commands::Transfer) then
+              when Commands::Transfer then
                 transfer_to_host(cmd.source, cmd.destination, host, 
                   :recursive => cmd.recursive?)
               else  
@@ -230,7 +231,7 @@ module Sprinkle
           scp.upload! source, destination, :recursive => opts[:recursive], :chunk_size => 32.kilobytes
         rescue RuntimeError => e
           if e.message =~ /Permission denied/
-            raise TransferFailure.no_permission(@installer,e)
+            raise Sprinkle::Errors::TransferFailure.no_permission(@installer,e)
           else
             raise e
           end          


### PR DESCRIPTION
Both when using the `file` installer and the `transfer` installer it failed when using `ssh` actor and `use_sudo true`.

This fixes the issues. Sorry for no specs.
