### PR TITLE
Fix rake namespace

### DIFF
--- a/lib/sprinkle/installers/thor.rb
+++ b/lib/sprinkle/installers/thor.rb
@@ -18,7 +18,7 @@ module Sprinkle
     #   package :spec do
     #     thor 'spec', :file => "/var/setup/Thorfile"
     #   end
-    class Thor < Sprinkle::Installer::Rake
+    class Thor < Sprinkle::Installers::Rake
       
       api do
         def thor(task, options = {}, &block)


### PR DESCRIPTION
When running rake tasks in my project that uses Sprinkle, I get an error (see below). This fixes it. Don't know how to test it with rspec.

It seems to be confusing `Sprinkle::Installers::Rake` class with some other `Rake` module.

```
$ bundle exec rake db:setup --trace
rake aborted!
wrong argument type Module (expected Class)
/home/pulver/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/bundler/gems/sprinkle-4ee75864ef77/lib/sprinkle/installers/thor.rb:21:in `<module:Installers>'
/home/pulver/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/bundler/gems/sprinkle-4ee75864ef77/lib/sprinkle/installers/thor.rb:2:in `<module:Sprinkle>'
/home/pulver/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/bundler/gems/sprinkle-4ee75864ef77/lib/sprinkle/installers/thor.rb:1:in `<top (required)>'
(...more lines outside sprinkle here)
```
