### PR TITLE
Relax "capistrano" dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     sprinkle (0.7.6.2)
       activesupport (>= 2.0.2)
-      capistrano (~> 2.5.5)
+      capistrano (>= 2.5.5, < 3)
       erubis (>= 2.7.0)
       highline (>= 1.4.0)
       open4 (>= 1.1.0)
@@ -28,12 +28,12 @@ GEM
       i18n (= 0.6.1)
       multi_json (~> 1.0)
     builder (3.0.4)
-    capistrano (2.5.21)
+    capistrano (2.15.5)
       highline
       net-scp (>= 1.0.0)
       net-sftp (>= 2.0.0)
       net-ssh (>= 2.0.14)
-      net-ssh-gateway (>= 1.0.0)
+      net-ssh-gateway (>= 1.1.0)
     coderay (1.0.9)
     diff-lcs (1.2.4)
     erubis (2.7.0)

--- a/sprinkle.gemspec
+++ b/sprinkle.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<open4>, [">= 1.1.0"])
   s.add_runtime_dependency(%q<activesupport>, [">= 2.0.2"])
   s.add_runtime_dependency(%q<highline>, [">= 1.4.0"])
-  s.add_runtime_dependency(%q<capistrano>, ["~> 2.5.5"])
+  s.add_runtime_dependency(%q<capistrano>, [">= 2.5.5", '< 3'])
 
 end
 


### PR DESCRIPTION
Don't use Capistrano 3, use the latest version 2 instead (see issue #171)
