### PR TITLE
correct group verifier to check a group exists on the system

### DIFF
--- a/lib/sprinkle/installers/group.rb
+++ b/lib/sprinkle/installers/group.rb
@@ -20,7 +20,7 @@ module Sprinkle
       
       verify_api do
         def has_group(group)
-          @commands << "id -g #{group}"
+          @commands << "egrep -i \"^#{group}:\" /etc/group"
         end
       end
       

--- a/spec/sprinkle/verify_spec.rb
+++ b/spec/sprinkle/verify_spec.rb
@@ -136,8 +136,8 @@ describe Sprinkle::Verify do
       @verification.commands.should include('id bob')
     end
     
-    it 'should use id to check for group' do
-      @verification.commands.should include('id -g bobgroup')
+    it 'should use egrep to check a group exists' do
+      @verification.commands.should include('egrep -i "^bobgroup:" /etc/group')
     end
 
     it 'should do a "test -L" to check something is a symbolic link' do


### PR DESCRIPTION
You cannot verify a group exists with `id -g` alone.
It's commonly incorrectly documented that you can run `id -g groupname` infact it is for displaying user and group information of the calling process, ie the current user, or if passed a specific user.
`usage: id -AGnMPgrpu [user]`

This patch correctly implements checking whether a group exists on a unix system.

Fixes #179 

Note:
I decided against using `getent` because it is no longer available on OSX since Apple started using DirectoryService instead of NetInfo
