### PR TITLE
Fix broken documentation.

### DIFF
--- a/lib/sprinkle/installers/installer.rb
+++ b/lib/sprinkle/installers/installer.rb
@@ -14,7 +14,7 @@ module Sprinkle
     # pre/post installation hooks. This gives you the ability to specify
     # commands to run before and after an installation takes place. 
     # There are three ways to specify a pre/post hook.
-    
+    #
     # Note about sudo:
     # When using the Capistrano actor all commands by default are run using
     # sudo (unless your Capfile includes "set :use_sudo, false").  If you wish 


### PR DESCRIPTION
The missing comment on line 17 breaks rdoc and yard, resulting in the documentation ([rdoc](http://www.ruby-doc.org/gems/docs/s/sprinkle-0.7.6.2/Sprinkle/Installers/Installer.html), [yard](http://rubydoc.info/gems/sprinkle/Sprinkle/Installers/Installer)) starting with a "note about sudo".
