### PR TITLE
Added namespace support for packages

### DIFF
--- a/lib/sprinkle.rb
+++ b/lib/sprinkle.rb
@@ -48,5 +48,5 @@ end
 # Define a logging target and understand packages, policies and deployment DSL
 #++
 class Object
-  include Sprinkle::Package, Sprinkle::Core, Sprinkle::Logger
+  include Sprinkle::Namespace, Sprinkle::Package, Sprinkle::Core, Sprinkle::Logger
 end

--- a/lib/sprinkle/core.rb
+++ b/lib/sprinkle/core.rb
@@ -1,7 +1,7 @@
 module Sprinkle
   # stores the global list of policies as they are defined
   POLICIES = []
-  
+
   module Core
     # Defines a single policy. Currently the only option, which is also
     # required, is :roles, which defines which servers a policy is
@@ -11,6 +11,6 @@ module Sprinkle
       POLICIES << p
       p
     end
-      
+
   end
 end

--- a/lib/sprinkle/namespace.rb
+++ b/lib/sprinkle/namespace.rb
@@ -1,0 +1,8 @@
+module Sprinkle
+  module Namespace
+    def namespace *args, &block
+      name = args.first
+      ::Sprinkle::Package::PACKAGES.in_scope name, &block
+    end
+  end
+end

--- a/lib/sprinkle/package/package_repository.rb
+++ b/lib/sprinkle/package/package_repository.rb
@@ -1,26 +1,28 @@
 module Sprinkle::Package
   class PackageRepository #:nodoc:
-    
+
     # sets up an empty repository
     def initialize
       clear
     end
-    
+
     def clear
       @packages = []
+      @scope = []
     end
-    
+
     # adds a single package to the repository
     def add(package)
+      package.name = ([@scope.join(':'), package.name].join(':')) if @scope.size > 0
       @packages << package
     end
     def <<(package); add(package); end
-    
+
     # returns the first package matching the name and options given
     def first(name, opts={})
       find_all(name, opts).try(:first)
     end
-    
+
     # returns all packages matching the name and options given (including via provides)
     def find_all(name, opts={})
       # opts ||= {}
@@ -28,21 +30,28 @@ module Sprinkle::Package
       find_all_by_provides(name, opts)].flatten.compact
       filter(all, opts)
     end
-            
+
     def count
       @packages.size
     end
-    
+
+    def in_scope name, &block
+      @scope << name
+      yield
+    ensure
+      @scope.pop
+    end
+
   private
-  
+
     def find_all_by_provides(name, opts={})
       @packages.select {|x| x.provides and x.provides.to_s == name.to_s }
     end
-    
+
     def filter(all, opts)
       all = all.select {|x| "#{x.version}" == opts[:version].to_s} if opts[:version]
       all
     end
-  
+
   end
 end

--- a/spec/sprinkle/namespace_spec.rb
+++ b/spec/sprinkle/namespace_spec.rb
@@ -1,0 +1,97 @@
+require File.expand_path("../spec_helper", File.dirname(__FILE__))
+
+describe Sprinkle::Policy do
+  include Sprinkle::Core
+
+  let(:empty) { Proc.new {} }
+  let(:name) { 'a package' }
+  let(:packages) { Sprinkle::Package::PACKAGES }
+  let(:packages_inner) { packages.instance_variable_get(:@packages) }
+
+  before do
+    Sprinkle::Package::PACKAGES.clear
+  end
+
+  after do
+    Sprinkle::Package::PACKAGES.clear
+  end
+
+  context 'with namespaces' do
+    it 'should support the namespace dsl syntax' do
+      expect {
+        namespace :a do
+          package name, &empty
+        end
+      }.not_to raise_error
+      expect(packages.count).to eq(1)
+      expect(packages_inner[0].name).to eq("a:#{name}")
+    end
+
+    it 'should not pollute namespaces' do
+      expect {
+        namespace :a do
+          package name, &empty
+        end
+        namespace :b do
+          package name, &empty
+        end
+      }.not_to raise_error
+      expect(packages.count).to eq(2)
+      expect(packages_inner[0].name).to eq("a:#{name}")
+      expect(packages_inner[1].name).to eq("b:#{name}")
+    end
+  end
+
+  context 'with nested namespaces' do
+    before do
+      expect {
+        namespace :a do
+          package name, &empty
+          namespace :b do
+            package name, &empty
+          end
+      end}.to_not raise_error
+    end
+
+    it 'should support nested namespaces' do
+      expect(packages.count).to eq(2)
+      expect(packages_inner[0].name).to eq("a:#{name}")
+      expect(packages_inner[1].name).to eq("a:b:#{name}")
+    end
+
+    it 'still be able to find packages' do
+      expect(packages.find_all("a:b:#{name}").size).to be(1)
+      expect(packages.find_all("a:#{name}").size).to be(1)
+    end
+  end
+
+  context 'with policies' do
+    before do
+      namespace :a do
+        @p1 = package name, &empty
+        namespace :b do
+          @p2 = package name, &empty
+        end
+      end
+
+      @deployment = double(Sprinkle::Deployment)
+      @deployment.stub(:style).and_return(double(:servers_for_role? => true))
+      @p1.stub(:instance).and_return(@p1)
+      @p2.stub(:instance).and_return(@p2)
+    end
+
+    it 'should support namespaced packages' do
+      p1,p2 = "a:#{name}", "a:b:#{name}"
+      p = policy 'policy', :roles => :app do
+        requires  p1
+        requires  p2
+      end
+
+      expect(p.packages).to include(p1,p2)
+      expect(@p1).to receive(:process)
+      expect(@p2).to receive(:process)
+      p.process(@deployment)
+    end
+
+  end
+end

--- a/spec/sprinkle/policy_spec.rb
+++ b/spec/sprinkle/policy_spec.rb
@@ -6,12 +6,12 @@ describe Sprinkle::Policy do
   before do
     @name = 'a policy'
   end
-  
+
   describe 'with a role with no matching servers' do
     before do
       @policy = policy @name, :roles => :app do; end
     end
-    
+
     it "should raise an error" do
       @deployment = double(:style => Sprinkle::Actors::Dummy.new {})
       lambda { @policy.process(@deployment) }.should raise_error(Sprinkle::NoMatchingServersError)


### PR DESCRIPTION
Added Namespeces. 

Similar to rake namespaces, package names have their namespace attached infront

```ruby
namespace :server do
  package :setup do
    gem 'sprinkle'
  end
end

policy :server, :provides => :app do
  requires 'server:setup'
end
```
