### PR TITLE
Require net-ssh lower than 2.8.0

### DIFF
--- a/sprinkle.gemspec
+++ b/sprinkle.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<open4>, [">= 1.1.0"])
   s.add_runtime_dependency(%q<activesupport>, [">= 2.0.2"])
   s.add_runtime_dependency(%q<highline>, [">= 1.4.0"])
+  s.add_runtime_dependency(%q<net-ssh>, ["< 2.8.0"])
   s.add_runtime_dependency(%q<capistrano>, [">= 2.5.5", '< 3'])
 
 end


### PR DESCRIPTION
Sprinkle SSH authentication does not work with `net-ssh` gem >= 2.8. It simply
fails even if the credentials are correct and were working before the upgrade. 

To reproduce the issue, specify version in Gemfile:

``` ruby
gem "net-ssh", "~> 2.8"
gem "sprinkle"
```

Define capistrano deployment:

``` ruby
deployment do
  delivery :capistrano do
    set :user,  "user"
    set :password, "password"
    role :app,  "localhost"
  end
```

Requiring `net-ssh` < 2.8 fixed the issue.
