### PR TITLE
Add pkgin installer.

### DIFF
--- a/lib/sprinkle/installers/pkgin.rb
+++ b/lib/sprinkle/installers/pkgin.rb
@@ -1,0 +1,39 @@
+module Sprinkle
+  module Installers
+    # The pkgin installer installs pkgsrc packages on Mac OS X.
+    #
+    # == Example Usage
+    #
+    # Installing the magic_beans package.
+    #
+    #   package :magic_beans do
+    #     pkgin 'magic_beans'
+    #   end
+    #
+    class Pkgin < PackageInstaller
+
+      attr_accessor :package_name
+
+      api do
+        def pkgin(package, &block)
+          install Pkgin.new(self, package, &block)
+        end
+      end
+      verify_api do
+        def has_pkgin(package)
+          @commands << "pkgin list | egrep '^#{@package_name}-'"
+        end
+      end
+      def initialize(parent, package_name, &block) #:nodoc:
+        super parent, &block
+        @package_name = package_name
+      end
+
+    protected
+
+      def install_commands #:nodoc:
+        "sudo /opt/pkg/bin/pkgin -y install #{@package_name}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
`pkgin` is a binary package manager for pkgsrc on BSD, macOS,
Linux, SunOS, Minix and SmartOS/Illumos.

---
 lib/sprinkle/installers/pkgin.rb | 39 +++++++++++++++++++++++++++++++++++++++
 1 file changed, 39 insertions(+)
 create mode 100644 lib/sprinkle/installers/pkgin.rb